### PR TITLE
Add an option for sanitizing commit message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
 
           # Sanitize commit message if requested
           if [[ "${{inputs.sanitize_commit_message}}" == "true" ]]; then
-            MSG_OLD=${MSG_OLD//---/...}
+            MSG_OLD=$(sed ':begin;$!N;s/^---\n/----\n/;tbegin' <<< "$MSG_OLD")
           fi
 
           MSG_CHANGE_ID="Change-Id: I${random}"

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
 
   sanitize_commit_message:
-    description: "Replace '---' divider with '...' to avoid problems with gerrit's commit-msg hook"
+    description: "Replace '---' divider with '----' to avoid problems with gerrit's commit-msg hook"
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Dont create anything'
     required: false
 
+  sanitize_commit_message:
+    description: "Replace '---' divider with '...' to avoid problems with gerrit's commit-msg hook"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -34,7 +38,7 @@ runs:
         shell: bash
         run: |
           git config user.name ${{ inputs.user }}
-          git config user.email ${{ inputs.email }} 
+          git config user.email ${{ inputs.email }}
 
       - name: Setup git remote
         shell: bash
@@ -73,6 +77,11 @@ runs:
           else
             MSG_PRE=""
             MSG_GH_PR=""
+          fi
+
+          # Sanitize commit message if requested
+          if [[ "${{inputs.sanitize_commit_message}}" == "true" ]]; then
+            MSG_OLD=${MSG_OLD//---/...}
           fi
 
           MSG_CHANGE_ID="Change-Id: I${random}"


### PR DESCRIPTION
Dependabot adds "---" to its commit messages automatically and when it's on gerrit, gerrit's `commit-msg` hook can't insert `Change-Id` into the right place.

More: https://phabricator.wikimedia.org/T295601
