### PR TITLE
Make username, gerrit host, and gerrit project fully configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,14 @@ inputs:
     description: "Replace '---' divider with '----' to avoid problems with gerrit's commit-msg hook"
     required: false
 
+  gitreview_project:
+    description: 'Gerrit project (if not defined, reads from .gitreview)'
+    required: false
+
+  gitreview_host:
+    description: 'Gerrit host (if not defined, reads from .gitreview)'
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -45,9 +53,12 @@ runs:
         env:
           DEPENDABOT_GERRIT_USER: ${{ inputs.user }}
           DEPENDABOT_GERRIT_PASSWORD: ${{ inputs.password }}
+          GITREVIEW_PROJECT: ${{ inputs.gitreview_project }}
+          GITREVIEW_HOST: ${{ inputs.gitreview_host }}
         run: |
-          GITREVIEW_PROJECT=$(sed -n '/project=/ { s///; s/\.git//; p; }' .gitreview)
-          GITREVIEW_HOST=$(sed -n '/host=/ s///p' .gitreview)
+          # Read these values from .gitreview if not provided
+          GITREVIEW_PROJECT=${GITREVIEW_PROJECT:-$(sed -n '/project=/ { s///; s/\.git//; p; }' .gitreview)}
+          GITREVIEW_HOST=${GITREVIEW_HOST:-$(sed -n '/host=/ s///p' .gitreview)}
           # Make available in subsequent steps as well, to avoid needing to recalculate
           echo "GITREVIEW_PROJECT=${GITREVIEW_PROJECT}" >> $GITHUB_ENV
           echo "GITREVIEW_HOST=${GITREVIEW_HOST}" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -43,17 +43,17 @@ runs:
       - name: Setup git remote
         shell: bash
         env:
+          DEPENDABOT_GERRIT_USER: ${{ inputs.user }}
           DEPENDABOT_GERRIT_PASSWORD: ${{ inputs.password }}
         run: |
           GITREVIEW_PROJECT=$(sed -n '/project=/ { s///; s/\.git//; p; }' .gitreview)
           GITREVIEW_HOST=$(sed -n '/host=/ s///p' .gitreview)
-          # Make available in the abandon step as well, to avoid needing to recalculate
+          # Make available in subsequent steps as well, to avoid needing to recalculate
           echo "GITREVIEW_PROJECT=${GITREVIEW_PROJECT}" >> $GITHUB_ENV
           echo "GITREVIEW_HOST=${GITREVIEW_HOST}" >> $GITHUB_ENV
 
           # Create the authenticated remote for gerrit
-          git remote add gerrit "https://addbot:${DEPENDABOT_GERRIT_PASSWORD}@${GITREVIEW_HOST}/r/a/${GITREVIEW_PROJECT}"
-
+          git remote add gerrit "https://${DEPENDABOT_GERRIT_USER}:${DEPENDABOT_GERRIT_PASSWORD}@${GITREVIEW_HOST}/r/a/${GITREVIEW_PROJECT}"
 
       # Generate the "randomness" for the change id from the branch name
       # This means that multiple alterations to the PR will submit to the same Gerrit change
@@ -95,7 +95,7 @@ runs:
           git log -n1
 
           ID_LINK=I${random}
-          echo "::warning::https://gerrit.wikimedia.org/r/q/$ID_LINK"
+          echo "::warning::https://${{ env.GITREVIEW_HOST }}/r/q/$ID_LINK"
 
       - name: Submit to Gerrit
         shell: bash
@@ -107,6 +107,7 @@ runs:
         if: ${{ github.event.action == 'closed' }}
         shell: bash
         env:
+          DEPENDABOT_GERRIT_USER: ${{ inputs.user }}
           DEPENDABOT_GERRIT_PASSWORD: ${{ inputs.password }}
         run: |
           # Project, host, and change id are added to the environment in prior steps
@@ -117,7 +118,5 @@ runs:
           GITREVIEW_CHANGE="$GITREVIEW_PROJECT_ESCAPED~${{ github.event.pull_request.base.ref }}~I${{ env.GITREVIEW_RANDOM_CHANGEID }}"
           # See https://gerrit.wikimedia.org/r/Documentation/rest-api-changes.html#abandon-change for the format
           ABANDON_URL=https://${{ env.GITREVIEW_HOST }}/r/a/changes/$GITREVIEW_CHANGE/abandon
-          COMMAND="curl -X POST --silent -u addbot:${DEPENDABOT_GERRIT_PASSWORD} $ABANDON_URL"
+          COMMAND="curl -X POST --silent -u ${DEPENDABOT_GERRIT_USER}:${DEPENDABOT_GERRIT_PASSWORD} $ABANDON_URL"
           $([[ "${{inputs.dry_run}}" == "true" ]] || $COMMAND > /dev/null)
-
-


### PR DESCRIPTION
Hello! 👋

Thanks for creating this great action! 😄 We use Gerrit for code review at my company as well, and so we share a similar problem of syncing Dependabot PRs back to Gerrit for review. This appears to be a great solution for that.

I noticed just a couple of places where the Gerrit username (and one place where the Gerrit host) appear to be hardcoded; this PR makes them fully configurable. (It also makes the Gerrit project configurable without the use of a `.gitreview` file).

Please let me know if this works or you have any concerns!

Thanks.